### PR TITLE
Plex MultiEpisode Patch

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -611,6 +611,7 @@ class xbmcnfotv(Agent.TV_Shows):
 										nfoepc = int(nfoTextLower.count('<episodedetails'))
 										nfopos = 1
 										multEpTitlePlexPatch = multEpSummaryPlexPatch = ""
+										multEpTestPlexPatch = false
 										while nfopos <= nfoepc:
 											self.DLog("EpNum: " + str(ep_num) + " NFOEpCount:" + str(nfoepc) +" Current EpNFOPos: " + str(nfopos))
 											# Remove URLs (or other stuff) at the end of the XML file
@@ -633,7 +634,12 @@ class xbmcnfotv(Agent.TV_Shows):
 												self.DLog('EpNum from NFO: ' + str(nfo_ep_num))
 											except: pass
 											
-											if Prefs['multEpisodePlexPatch'] and nfoepc > 1:
+											# Checks to see if first episode in file for Plex MultiEpisode Patch
+											if (nfopos == 1) and (int(nfo_ep_num) == int(ep_num)):
+												multEpTestPlexPatch = true
+											
+											# Creates combined strings for Plex MultiEpisode Patch
+											if multEpTestPlexPatch and Prefs['multEpisodePlexPatch'] and (nfoepc > 1):
 												try:
 													if nfopos == 1:
 														multEpTitlePlexPatch = nfoXML.xpath('title')[0].text
@@ -643,7 +649,7 @@ class xbmcnfotv(Agent.TV_Shows):
 														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "(" + nfoXML.xpath('title')[0].text + ")" + nfoXML.xpath('plot')[0].text
 												except: pass
 											
-											if not Prefs['multEpisodePlexPatch']:
+											if not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):
 												if int(nfo_ep_num) == int(ep_num):
 													nfoText = nfoTextTemp
 													break
@@ -655,7 +661,7 @@ class xbmcnfotv(Agent.TV_Shows):
 											return
 
 										# Ep. Title
-										if Prefs['multEpisodePlexPatch'] and multEpTitlePlexPatch != "":
+										if Prefs['multEpisodePlexPatch'] and (multEpTitlePlexPatch != ""):
 											episode.title = multEpTitlePlexPatch
 										else:
 											try: episode.title = nfoXML.xpath('title')[0].text
@@ -705,7 +711,7 @@ class xbmcnfotv(Agent.TV_Shows):
 											self.DLog("Exception parsing Ep Premiere: " + traceback.format_exc())
 											pass
 										# Ep. Summary
-										if Prefs['multEpisodePlexPatch'] and multEpSummaryPlexPatch != "":
+										if Prefs['multEpisodePlexPatch'] and (multEpSummaryPlexPatch != ""):
 											episode.summary = multEpSummaryPlexPatch
 										else:
 											try: episode.summary = nfoXML.xpath('plot')[0].text

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -644,10 +644,10 @@ class xbmcnfotv(Agent.TV_Shows):
 												try:
 													if nfopos == 1:
 														multEpTitlePlexPatch = nfoXML.xpath('title')[0].text
-														multEpSummaryPlexPatch = "(" + nfoXML.xpath('title')[0].text + ") " + nfoXML.xpath('plot')[0].text
+														multEpSummaryPlexPatch = "[Episode #" + str(nfo_ep_num) + " - " + nfoXML.xpath('title')[0].text + "] " + nfoXML.xpath('plot')[0].text
 													else:
 														multEpTitlePlexPatch = multEpTitlePlexPatch + " : " + nfoXML.xpath('title')[0].text
-														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "(" + nfoXML.xpath('title')[0].text + ") " + nfoXML.xpath('plot')[0].text
+														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "[Episode #" + str(nfo_ep_num) + " - " + nfoXML.xpath('title')[0].text + "] " + nfoXML.xpath('plot')[0].text
 												except: pass
 											
 											if not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -837,7 +837,7 @@ class xbmcnfotv(Agent.TV_Shows):
 										episodeThumbNames = []
 
 										#Multiepisode nfo thumbs
-										if nfoepc > 1:
+										if (nfoepc > 1) and not Prefs['multEpisodePlexPatch']:
 											for name in glob.glob1(os.path.dirname(nfoFile), '*S' + str(season_num.zfill(2)) + 'E' + str(ep_num.zfill(2)) + '*.*'):
 												if "-E" in name: continue
 												episodeThumbNames.append (os.path.join(os.path.dirname(nfoFile), name))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -611,7 +611,7 @@ class xbmcnfotv(Agent.TV_Shows):
 										nfoepc = int(nfoTextLower.count('<episodedetails'))
 										nfopos = 1
 										multEpTitlePlexPatch = multEpSummaryPlexPatch = ""
-										multEpTestPlexPatch = false
+										multEpTestPlexPatch = 0
 										while nfopos <= nfoepc:
 											self.DLog("EpNum: " + str(ep_num) + " NFOEpCount:" + str(nfoepc) +" Current EpNFOPos: " + str(nfopos))
 											# Remove URLs (or other stuff) at the end of the XML file
@@ -636,16 +636,17 @@ class xbmcnfotv(Agent.TV_Shows):
 											
 											# Checks to see if first episode in file for Plex MultiEpisode Patch
 											if (nfopos == 1) and (int(nfo_ep_num) == int(ep_num)):
-												multEpTestPlexPatch = true
+												multEpTestPlexPatch = 1
 											
 											# Creates combined strings for Plex MultiEpisode Patch
 											if multEpTestPlexPatch and Prefs['multEpisodePlexPatch'] and (nfoepc > 1):
+												self.DLog('Multi Episode found: ' + str(nfo_ep_num))
 												try:
 													if nfopos == 1:
 														multEpTitlePlexPatch = nfoXML.xpath('title')[0].text
 														multEpSummaryPlexPatch = "(" + nfoXML.xpath('title')[0].text + ")" + nfoXML.xpath('plot')[0].text
 													else:
-														multEpTitlePlexPatch = multEpTitlePlexPatch + " : " nfoXML.xpath('title')[0].text
+														multEpTitlePlexPatch = multEpTitlePlexPatch + " : " + nfoXML.xpath('title')[0].text
 														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "(" + nfoXML.xpath('title')[0].text + ")" + nfoXML.xpath('plot')[0].text
 												except: pass
 											
@@ -662,6 +663,7 @@ class xbmcnfotv(Agent.TV_Shows):
 
 										# Ep. Title
 										if Prefs['multEpisodePlexPatch'] and (multEpTitlePlexPatch != ""):
+											self.DLog('using multi title: ' + multEpTitlePlexPatch)
 											episode.title = multEpTitlePlexPatch
 										else:
 											try: episode.title = nfoXML.xpath('title')[0].text
@@ -712,6 +714,7 @@ class xbmcnfotv(Agent.TV_Shows):
 											pass
 										# Ep. Summary
 										if Prefs['multEpisodePlexPatch'] and (multEpSummaryPlexPatch != ""):
+											self.DLog('using multi summary: ' + multEpSummaryPlexPatch)
 											episode.summary = multEpSummaryPlexPatch
 										else:
 											try: episode.summary = nfoXML.xpath('plot')[0].text

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -644,10 +644,10 @@ class xbmcnfotv(Agent.TV_Shows):
 												try:
 													if nfopos == 1:
 														multEpTitlePlexPatch = nfoXML.xpath('title')[0].text
-														multEpSummaryPlexPatch = "(" + nfoXML.xpath('title')[0].text + ")" + nfoXML.xpath('plot')[0].text
+														multEpSummaryPlexPatch = "(" + nfoXML.xpath('title')[0].text + ") " + nfoXML.xpath('plot')[0].text
 													else:
 														multEpTitlePlexPatch = multEpTitlePlexPatch + " : " + nfoXML.xpath('title')[0].text
-														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "(" + nfoXML.xpath('title')[0].text + ")" + nfoXML.xpath('plot')[0].text
+														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "(" + nfoXML.xpath('title')[0].text + ") " + nfoXML.xpath('plot')[0].text
 												except: pass
 											
 											if not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -635,7 +635,7 @@ class xbmcnfotv(Agent.TV_Shows):
 											except: pass
 											
 											# Checks to see if first episode in file for Plex MultiEpisode Patch
-											if (nfopos == 1) and (int(nfo_ep_num) == int(ep_num)):
+											if (nfopos == 1) and (int(nfo_ep_num) == int(ep_num)) and (nfoepc > 1):
 												multEpTestPlexPatch = 1
 											
 											# Creates combined strings for Plex MultiEpisode Patch
@@ -657,7 +657,7 @@ class xbmcnfotv(Agent.TV_Shows):
 											
 											nfopos = nfopos + 1
 
-										if nfopos > nfoepc:
+										if not multEpTestPlexPatch and not Prefs['multEpisodePlexPatch'] and (nfopos > nfoepc):
 											self.DLog('No matching episode in nfo file!')
 											return
 

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -70,7 +70,7 @@
     "default":"false"
   },
   {
-    "id":"multEpisodeCombine",
+    "id":"multEpisodePlexPatch",
     "label":"Combine multiple episodes\n Multi episodes file naming must differ from plex naming convention to remove\\hide latter episodes from Plex scanner! (e.g. S01E01-02 instead of S01E01-E02)",
     "type":"bool",
     "default":"false"

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -68,5 +68,11 @@
     "label":"enable additional ratings support",
     "type":"bool",
     "default":"false"
+  },
+  {
+    "id":"multEpisodeCombine",
+    "label":"Combine multiple episodes\n Multi episodes file naming must differ from plex naming convention to remove\\hide latter episodes from Plex scanner! (e.g. S01E01-02 instead of S01E01-E02)",
+    "type":"bool",
+    "default":"false"
   }
 ]


### PR DESCRIPTION
Combines titles and summaries for NFOs that are named in a way so that Plex can't tell they are multiepisodes. Is aware of files that haven't been renamed and doesn't apply method. Default option is false for this
