### PR TITLE
Plex MultiEpisode Patch (Regex test for file Names)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -7,7 +7,7 @@
 # Cleanup and some extensions by SlrG
 # Logo by CrazyRabbit
 #
-import os, re, time, datetime, platform, traceback, glob, re, htmlentitydefs
+import os, re, time, datetime, platform, traceback, glob, re, htmlentitydefsp
 from dateutil.parser import parse
 
 PERCENT_RATINGS = {
@@ -650,7 +650,7 @@ class xbmcnfotv(Agent.TV_Shows):
 														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "[Episode #" + str(nfo_ep_num) + " - " + nfoXML.xpath('title')[0].text + "] " + nfoXML.xpath('plot')[0].text
 												except: pass
 											
-											if not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):
+											if not multEpTestPlexPatch or not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):
 												if int(nfo_ep_num) == int(ep_num):
 													nfoText = nfoTextTemp
 													break

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -649,15 +649,14 @@ class xbmcnfotv(Agent.TV_Shows):
 														multEpTitlePlexPatch = multEpTitlePlexPatch + " : " + nfoXML.xpath('title')[0].text
 														multEpSummaryPlexPatch = multEpSummaryPlexPatch + "\n" + "[Episode #" + str(nfo_ep_num) + " - " + nfoXML.xpath('title')[0].text + "] " + nfoXML.xpath('plot')[0].text
 												except: pass
-											
-											if not multEpTestPlexPatch or not Prefs['multEpisodePlexPatch'] or (nfoepc == 1):
+											else:
 												if int(nfo_ep_num) == int(ep_num):
 													nfoText = nfoTextTemp
 													break
 											
 											nfopos = nfopos + 1
 
-										if not multEpTestPlexPatch and not Prefs['multEpisodePlexPatch'] and (nfopos > nfoepc):
+										if (not multEpTestPlexPatch or not Prefs['multEpisodePlexPatch']) and (nfopos > nfoepc):
 											self.DLog('No matching episode in nfo file!')
 											return
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -634,8 +634,8 @@ class xbmcnfotv(Agent.TV_Shows):
 												self.DLog('EpNum from NFO: ' + str(nfo_ep_num))
 											except: pass
 											
-											# Checks to see if first episode in file for Plex MultiEpisode Patch
-											if (nfopos == 1) and (int(nfo_ep_num) == int(ep_num)) and (nfoepc > 1):
+											# Checks to see user has renamed files so plex ignores multiepisodes and confirms that there is more than on episodedetails
+											if not re.search('.s\d{1,3}e\d{1,3}e\d{1,3}.', path1.lower()) and not re.search('.s\d{1,3}e\d{1,3}-e\d{1,3}.', path1.lower()) and (nfoepc > 1):
 												multEpTestPlexPatch = 1
 											
 											# Creates combined strings for Plex MultiEpisode Patch

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -71,7 +71,7 @@
   },
   {
     "id":"multEpisodePlexPatch",
-    "label":"Combine multiple episodes\n Multi episodes file naming must differ from plex naming convention to remove\\hide latter episodes from Plex scanner! (e.g. S01E01-02 instead of S01E01-E02)",
+    "label":"Combine multiple episodes infos. (File naming for multiple episodes must differ from plex naming convention to remove/hide latter episodes from Plex scanner! (e.g. S01E01-02 instead of S01E01-E02))",
     "type":"bool",
     "default":"false"
   }


### PR DESCRIPTION
Using SlrG's tip involving a regex test, replaced my old method (that didn't fully work) that tried to do a courtesy check to make sure the file name was "incompatible" with Plex. Also cleaned up the option description.
